### PR TITLE
Grab URLs from Hacker News comments

### DIFF
--- a/60_news-ycombinator.txt
+++ b/60_news-ycombinator.txt
@@ -1,0 +1,1 @@
+random=RANDOM;all=1;keep_all=1;depth=1;url=https://news.ycombinator.com/newcomments


### PR DESCRIPTION
The comments often have URLs that don't get posted as articles.

60s refresh because the new comments page only keeps a few minutes worth.
