### PR TITLE
Add https://www.whitehouse.gov/wp-json/whitehouse/v1/schedule and https://www.whitehouse.gov/wp-json/whitehouse/v1/social/truth

### DIFF
--- a/900_whitehouse.gov.txt
+++ b/900_whitehouse.gov.txt
@@ -50,3 +50,5 @@ all=1;deep_extract=1;random=RANDOM;depth=1;keep_random=0;keep_all=1;any_domain=1
 all=1;deep_extract=1;random=RANDOM;depth=1;keep_random=0;keep_all=1;any_domain=1;https://www.whitehouse.gov/wp-json/whitehouse/v1/priorities
 all=1;deep_extract=1;random=RANDOM;depth=1;keep_random=0;keep_all=1;any_domain=1;https://www.whitehouse.gov/wp-json/whitehouse/v1/social/x
 all=1;deep_extract=1;random=RANDOM;depth=1;keep_random=0;keep_all=1;any_domain=1;https://www.whitehouse.gov/wp-json/whitehouse/v1/wire
+all=1;deep_extract=1;random=RANDOM;depth=1;keep_random=0;keep_all=1;any_domain=1;https://www.whitehouse.gov/wp-json/whitehouse/v1/schedule
+all=1;deep_extract=1;random=RANDOM;depth=1;keep_random=0;keep_all=1;any_domain=1;https://www.whitehouse.gov/wp-json/whitehouse/v1/social/truth


### PR DESCRIPTION
These were added at some point since my previous PR (but I haven't been actively looking for updates, and only noticed when I reran my manual script and the assertions I added checking for changes to https://www.whitehouse.gov/wp-json/whitehouse/v1 failed).

schedule is available in the morning and lists the daily schedule (at night it is empty), while social/truth mirrors Truth Social posts (and seems to have a more complete history, as opposed to social/x which gives up after a few pages (though #// will only be saving the first page))