### PR TITLE
Add Transformers @ The Moon (extremely old UK Transformers fansite) RSS feeds

### DIFF
--- a/3600_transformers_at_the_moon.txt
+++ b/3600_transformers_at_the_moon.txt
@@ -1,0 +1,6 @@
+random=RANDOM;all=1;keep_all=1;depth=1;deep_extract=1;http://www.transformertoys.co.uk/feeds/rss/news.xml
+random=RANDOM;all=1;keep_all=1;depth=1;deep_extract=1;http://www.transformertoys.co.uk/feeds/rss/cartoon.xml
+random=RANDOM;all=1;keep_all=1;depth=1;deep_extract=1;http://www.transformertoys.co.uk/feeds/rss/comic.xml
+random=RANDOM;all=1;keep_all=1;depth=1;deep_extract=1;http://www.transformertoys.co.uk/feeds/rss/video.xml
+random=RANDOM;all=1;keep_all=1;depth=1;deep_extract=1;http://www.transformertoys.co.uk/feeds/rss/new-discussion.xml
+random=RANDOM;all=1;keep_all=1;depth=1;deep_extract=1;http://www.transformertoys.co.uk/feeds/rss/recent-discussion.xml


### PR DESCRIPTION
Added because the site is clearly vulnerable to becoming lost media despite being a former news partner to healthy Transformers forum TFW2005; notably, it still uses HTTP and hasn't switched, it is clearly dated in web design, rarely updated (still has dated links on front page) and has some quirks from sites around its time. (namely the Missing Person 404 not found page)